### PR TITLE
fix for network side-effect on image.src = *undefined*

### DIFF
--- a/src/VImageInput/methods/load.js
+++ b/src/VImageInput/methods/load.js
@@ -23,6 +23,6 @@ export default function({ file, base64: data }) {
 				lastModified: file.lastModified || ''
 			})
 		}
-		image.src = data;
+		if (data) image.src = data;
 	}
 }


### PR DESCRIPTION
Each move of loaded image in the cropping area causes new call for "load" method, which tries to assign image.src with "undefined" at this moment "data". Eventually "Img" HTML tag tries to receive from server data by url "undefined"

![image](https://user-images.githubusercontent.com/60133730/110905629-58bda780-833d-11eb-844a-7d736d8ff8dc.png)

P.S. Sorry, i`m new to webpack and I don`t know how to build this package correctly. 
>>npm run build doesn`t work for me:C